### PR TITLE
SCRUM-84 refact: seller객체와 role db에서 null 가능하게 변경

### DIFF
--- a/src/main/java/com/kakaoteck/golagola/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kakaoteck/golagola/domain/auth/controller/AuthController.java
@@ -28,38 +28,10 @@ public class AuthController {
 
     private final AuthService1 authService;
 
-    // 해당하는 유저에다가 추가적인 정보 저장하기
-
-//    @Operation(summary = "회원가입 추가정보 진행", description = "(nickname, gender) 저장")
-//    @PostMapping("/join")
-//    public ApiResponse<String> join(@RequestBody AuthRequest authRequest, @AuthenticationPrincipal CustomOAuth2User customUser) {
-//        String username = customUser.getUsername();
-//
-//        // 1. UserService를 통해 (nickname, gender) 저장
-//        authService.saveUserDetails(username, authRequest);
-//
-//        // 2. 기존 UserDTO를 업데이트
-//        UserDTO updatedUserDTO = customUser.getUserDTO();
-//        updatedUserDTO.setNickname(authRequest.nickName());
-//        updatedUserDTO.setGender(authRequest.gender());
-//
-//
-//        // 3. CustomOAuth2User 객체 업데이트 (UserEntity 유지)
-//        UserEntity userEntity = customUser.getUserEntity(); // 기존 UserEntity 유지
-//        CustomOAuth2User updatedCustomOAuth2User = new CustomOAuth2User(updatedUserDTO, userEntity);
-//
-//        Authentication newAuth = new UsernamePasswordAuthenticationToken(updatedCustomOAuth2User, null, updatedCustomOAuth2User.getAuthorities());
-//
-//        // 5. SecurityContextHolder에 새로운 Authentication 객체로 업데이트
-//        SecurityContextHolder.getContext().setAuthentication(newAuth);
-//
-//        return ApiResponse.onSuccess("회원가입 성공");
-//    }
-
     @Operation(summary = "회원가입 추가정보 진행", description = "(nickname, gender, role) 저장")
     @PostMapping("/join")
     public ApiResponse<String> join(@RequestBody AuthRequest authRequest, @AuthenticationPrincipal CustomOAuth2User customUser) {
-        String username = customUser.getUsername();
+//        String username = customUser.getUsername();
 
         // 1. UserEntity 가져오기
         UserEntity userEntity = customUser.getUserEntity();
@@ -83,15 +55,12 @@ public class AuthController {
                     .address(authRequest.address())
                     .build();
             userEntity.setBuyer(buyer);  // UserEntity에 Buyer 설정
-//        } else if ("SELLER".equalsIgnoreCase(authRequest.role())) {
-//            Seller seller = Seller.builder()
-//                    .user(userEntity)
-//                    .businessName(authRequest.address()) // Seller의 추가 정보
-//                    .role(Role.SELLER)
-//                    .build();
-//            userEntity.setSeller(seller);  // UserEntity에 Seller 설정
-//            Authentication newAuth = new UsernamePasswordAuthenticationToken(seller, null, customUser.getAuthorities());
-//            SecurityContextHolder.getContext().setAuthentication(newAuth);
+        } else if (Role.SELLER == authRequest.role()) {
+            Seller seller = Seller.builder()
+                    .user(userEntity)
+                    .address(authRequest.address())
+                    .build();
+            userEntity.setSeller(seller);  // UserEntity에 Seller 설정
         } else {
             return ApiResponse.onFailure("Invalid role");
         }

--- a/src/main/java/com/kakaoteck/golagola/domain/auth/entity/UserEntity.java
+++ b/src/main/java/com/kakaoteck/golagola/domain/auth/entity/UserEntity.java
@@ -40,8 +40,9 @@ public class UserEntity implements UserDetails {
     private Gender gender = Gender.valueOf("MALE");
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private Role role = Role.valueOf("BUYER");
+//    @Column(nullable = false)
+//    private Role role = Role.valueOf("BUYER");
+    private Role role;
 
     // 추가
     private String refreshToken; // JWT 리프레시 토큰 발급

--- a/src/main/java/com/kakaoteck/golagola/domain/buyer/controller/BuyerController.java
+++ b/src/main/java/com/kakaoteck/golagola/domain/buyer/controller/BuyerController.java
@@ -25,21 +25,9 @@ public class BuyerController {
 
     private final BuyerService buyerService;
 
-//    @Operation(summary = "구매자 마이페이지 조회", description = "구매자의 정보를 조회합니다.")
-//    @GetMapping("/mypage")
-//    public ApiResponse<BuyerResponse> getMyPage(@AuthenticationPrincipal CustomOAuth2User customUser) {
-//
-//        UserEntity userEntity = customUser.getUserEntity();
-//        BuyerResponse buyerResponse = BuyerService.getMyPage(userEntity); // Buyer 객체를 BuyerService로 넘겨서 BuyerResponse 생성
-//        return ApiResponse.onSuccess(buyerResponse);
-//    }
-
     @Operation(summary = "구매자 마이페이지 조회", description = "구매자의 정보를 조회합니다.")
     @GetMapping("/mypage")
     public ApiResponse<BuyerResponse> getMyPage(@AuthenticationPrincipal Buyer buyer) {
-
-//        UserEntity userEntity = customUser.getUserEntity();
-//        BuyerResponse buyerResponse = BuyerService.getMyPage(userEntity); // Buyer 객체를 BuyerService로 넘겨서 BuyerResponse 생성
         BuyerResponse buyerResponse = BuyerService.getMyPage(buyer);
         return ApiResponse.onSuccess(buyerResponse);
     }

--- a/src/main/java/com/kakaoteck/golagola/domain/buyer/entity/Buyer.java
+++ b/src/main/java/com/kakaoteck/golagola/domain/buyer/entity/Buyer.java
@@ -32,12 +32,11 @@ public class Buyer extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long buyerId;
+    private String address; // @Column(nullable = false)
 
     @OneToOne // Buyer는 하나의 UserEntity와만 연결됩니다.
     @JoinColumn(name = "user_id", nullable = false)
     private UserEntity user;
-
-    private String address; // @Column(nullable = false)
 
 //    @Enumerated(EnumType.STRING)
 //    @Column(nullable = false)

--- a/src/main/java/com/kakaoteck/golagola/domain/buyer/service/BuyerService.java
+++ b/src/main/java/com/kakaoteck/golagola/domain/buyer/service/BuyerService.java
@@ -6,6 +6,7 @@ import com.kakaoteck.golagola.domain.buyer.dto.BuyerRequest;
 import com.kakaoteck.golagola.domain.buyer.dto.BuyerResponse;
 import com.kakaoteck.golagola.domain.buyer.entity.Buyer;
 import com.kakaoteck.golagola.domain.buyer.repository.BuyerRepository;
+import com.kakaoteck.golagola.domain.seller.entity.Seller;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -21,15 +22,6 @@ public class BuyerService {
     private final UserRepository userRepository;
 
     public static BuyerResponse getMyPage(Buyer buyer) {
-//        return BuyerResponse.builder()
-//                .email(userEntity.getEmail())
-//                .role(userEntity.getRole())
-//                .address(userEntity.getBuyer().getAddress())
-//                .realName(userEntity.getName())
-//                .gender(userEntity.getGender())
-//                .phoneNum(userEntity.getPhoneNum())
-//                .nickname(userEntity.getNickname())
-//                .build();
         return BuyerResponse.builder()
                 .email(buyer.getUser().getEmail())
                 .role(buyer.getUser().getRole())
@@ -41,41 +33,21 @@ public class BuyerService {
                 .build();
     }
 
-//    public BuyerResponse updateMyPage(@AuthenticationPrincipal CustomOAuth2User customUser, BuyerRequest.MyPagePutDto request) {
-//        Buyer buyer = buyerRepository.findByUser(userEntity)
-//                .orElseThrow(() -> new IllegalArgumentException("Buyer not found"));
-//
-//        buyer.updateProfile(request);
-//
-//        // 3. Buyer 및 UserEntity 정보 저장
-//        buyerRepository.save(buyer);
-//        userRepository.save(userEntity);
-//
-//        return BuyerResponse.builder()
-//                .email(userEntity.getEmail())
-//                .role(userEntity.getRole())
-//                .address(userEntity.getBuyer().getAddress())
-//                .realName(userEntity.getName())
-//                .gender(userEntity.getGender())
-//                .phoneNum(userEntity.getPhoneNum())
-//                .nickname(userEntity.getNickname())
-//                .build();
-//    }
 public BuyerResponse updateMyPage(Buyer buyer, BuyerRequest.MyPagePutDto request) {
     buyer.updateProfile(request);
 
-    // 3. Buyer 및 UserEntity 정보 저장
-    buyerRepository.save(buyer);
+    // Buyer 및 UserEntity 정보 저장
+    Buyer savedBuyer = buyerRepository.save(buyer);
     userRepository.save(buyer.getUser());
 
     return BuyerResponse.builder()
-            .email(buyer.getUser().getEmail())
-            .role(buyer.getUser().getRole())
-            .address(buyer.getAddress())
-            .realName(buyer.getUser().getName())
-            .gender(buyer.getUser().getGender())
-            .phoneNum(buyer.getUser().getPhoneNum())
-            .nickname(buyer.getUser().getNickname())
+            .email(savedBuyer.getUser().getEmail())
+            .role(savedBuyer.getUser().getRole())
+            .address(savedBuyer.getAddress())
+            .realName(savedBuyer.getUser().getName())
+            .gender(savedBuyer.getUser().getGender())
+            .phoneNum(savedBuyer.getUser().getPhoneNum())
+            .nickname(savedBuyer.getUser().getNickname())
             .build();
-}
+    }
 }

--- a/src/main/java/com/kakaoteck/golagola/domain/seller/entity/Seller.java
+++ b/src/main/java/com/kakaoteck/golagola/domain/seller/entity/Seller.java
@@ -30,20 +30,14 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-//@SuperBuilder
+@Builder
 @Table(name = "seller_table")
-//@DiscriminatorValue("SELLER")
 public class Seller extends BaseEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long sellerId;
-
     private String address; //  @Column(nullable = false)
-
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private Role role = Role.valueOf("SELLER");
 
     @OneToOne // Seller는 하나의 UserEntity와만 연결됩니다.
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/com/kakaoteck/golagola/domain/seller/service/SellerService.java
+++ b/src/main/java/com/kakaoteck/golagola/domain/seller/service/SellerService.java
@@ -1,5 +1,6 @@
 package com.kakaoteck.golagola.domain.seller.service;
 
+import com.kakaoteck.golagola.domain.auth.Repository.UserRepository;
 import com.kakaoteck.golagola.domain.seller.dto.SellerRequest;
 import com.kakaoteck.golagola.domain.seller.dto.SellerResponse;
 import com.kakaoteck.golagola.domain.seller.entity.Seller;
@@ -16,13 +17,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class SellerService {
 
     private final SellerRepository sellerRepository;
+    private final UserRepository userRepository;
 
     public SellerResponse getMyPage(Seller seller) {
         return SellerResponse.builder()
                 .email(seller.getUser().getEmail())
-                .role(seller.getRole())
+                .role(seller.getUser().getRole())
                 .address(seller.getAddress())
-//                .registerDate(seller.getRegisterDate())
                 .realName(seller.getUser().getName())
                 .gender(seller.getUser().getGender())
                 .phoneNum(seller.getUser().getPhoneNum())
@@ -33,12 +34,15 @@ public class SellerService {
 
     public SellerResponse updateMyPage(Seller seller, SellerRequest.MyPagePutDto request) {
         seller.updateProfile(request);
+
+        // Seller 및 UserEntity 정보 저장
         Seller savedSeller = sellerRepository.save(seller);
+        userRepository.save(seller.getUser());
+
         return SellerResponse.builder()
                 .email(savedSeller.getUser().getEmail())
-                .role(savedSeller.getRole())
+                .role(savedSeller.getUser().getRole())
                 .address(savedSeller.getAddress())
-//                .registerDate(savedSeller.getRegisterDate())
                 .realName(savedSeller.getUser().getName())
                 .gender(savedSeller.getUser().getGender())
                 .phoneNum(savedSeller.getUser().getPhoneNum())

--- a/src/main/java/com/kakaoteck/golagola/security/jwt/JWTFilter.java
+++ b/src/main/java/com/kakaoteck/golagola/security/jwt/JWTFilter.java
@@ -101,21 +101,18 @@ public class JWTFilter extends OncePerRequestFilter {
 //        userDTO.setRole(role); // buyer, seller받아오는걸로 바꾸기
 
         Authentication authToken = null;
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(userDTO, userEntity); // UserDetails에 회원 정보 객체 담기
         // 연관된 1대1 매핑에 값이 존재할 때(CustomOAuth2User, buyer, seller)로 받기
         if (userEntity.getRole() == Role.BUYER) {
             Buyer buyer = userEntity.getBuyer();  // 1:1 매핑된 Buyer 가져오기
-
-            CustomOAuth2User customOAuth2User = new CustomOAuth2User(userDTO, userEntity);
             authToken = new UsernamePasswordAuthenticationToken(buyer, null, customOAuth2User.getAuthoritiesForRole(Role.BUYER));  // Buyer에 맞는 권한 설정
         }
         else if (userEntity.getRole() == Role.SELLER){
             Seller seller = userEntity.getSeller();  // 1:1 매핑된 Seller 가져오기
-
-            CustomOAuth2User customOAuth2User = new CustomOAuth2User(userDTO, userEntity);
             authToken = new UsernamePasswordAuthenticationToken(seller, null, customOAuth2User.getAuthoritiesForRole(Role.SELLER));  // Seller에 맞는 권한 설정
         }
         else{
-            CustomOAuth2User customOAuth2User = new CustomOAuth2User(userDTO, userEntity); // UserDetails에 회원 정보 객체 담기
+            System.out.println("여기 걸리냐/?!!!!!!");
             authToken = new UsernamePasswordAuthenticationToken(customOAuth2User, null, customOAuth2User.getAuthorities()); // 스프링 시큐리티 인증 토큰 생성, 스프링 시큐리티에서 세션을 생성해가지고 토큰을 등록하고 있음.
         }
         SecurityContextHolder.getContext().setAuthentication(authToken); // 세션에 사용자 등록


### PR DESCRIPTION
# ☝️Issue Number

- #52 

# 🔎 Key Changes
- buyer랑 seller 원래 지미코드대로 리팩토링

# 💌 To Reviewers
- db에 role값 not null 풀어주어야함, null 허용으로 바꾸어야함, 왜냐하면 로그인하고 그 이후에 추가정보로 role값을 받어야 하기 때문에 
처음에 소셜로그인만 진행하면 role값이 존재하지않아서 그 기간동안 null값이 유지되어야 함.(사용자가 악의적인 행동으로 로그인하고 종료하거나 계속해서 추가 정보를 받지 않아서 null값으로 계속 존재할지도 모르기 때문) 그 기간동안은 null값으로 존재해야함
